### PR TITLE
remove '--harmony' from shebang (#3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
 
 const program = require('commander');
 const awsGetStack = require('./lib/stack');


### PR DESCRIPTION
/usr/bin/env may not support arguments:

  $ cf-to-tf
  /usr/bin/env: 'node --harmony': No such file or directory

Also see:

  https://github.com/lambtron/emojipacks/issues/94
  https://github.com/passbolt/passbolt_cli/issues/6
  https://github.com/njpatel/grpcc/issues/10