### PR TITLE
strip trailing commas in JSON lists/objects

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -6,5 +6,5 @@ module.exports = opts => {
 		StackName: opts.stack,
 	})
 		.promise()
-		.then(result => JSON.parse(result.TemplateBody));
+		.then(result => JSON.parse(result.TemplateBody.replace(/,(\s*[})\]])/g, '$1')));
 };

--- a/tests/template_allow_trailing_commas.js
+++ b/tests/template_allow_trailing_commas.js
@@ -1,0 +1,14 @@
+const awsGetTemplate = require('./../lib/template');
+const AWS = require('aws-sdk-mock');
+
+describe('', () => {
+	test('allow_trailing_commas_in_template', () => {
+		AWS.mock('CloudFormation', 'getTemplate', {
+			TemplateBody: '{"mocked": [true,], "trailing commas": "are OK",}',
+		});
+		const expected = {"mocked": [true], "trailing commas": "are OK"};
+		return awsGetTemplate({}).then(result => {
+			expect(result).toEqual(expected);
+		});
+	});
+});


### PR DESCRIPTION
CloudFormation templates accept a "loose" JSON structure where
trailing commas in lists/objects are allowed, but this fails
when processing the source content with JSON.parse:

    SyntaxError: Unexpected token } in JSON at position X at JSON.parse (<anonymous>)
    at CF.getTemplate.promise.then.result (.../cf-to-tf/lib/template.js:9:24)
    at process._tickCallback (internal/process/next_tick.js:68:7)

This crude hack attempts to strip trailing commas before passing the
template body to JSON.parse.

If you are using @nathanielks 's scripts from https://gist.github.com/nathanielks/9282d59ab065f8ee0e373ca7199df085, the error would manifest as:

    parse error: Invalid numeric literal ...

when the (error) output from cf-to-tf is passed to jq at https://gist.github.com/nathanielks/9282d59ab065f8ee0e373ca7199df085#file-import-stack-sh-L52

Hope this helps anyone else who runs into this.