### PR TITLE
README: update example with paste-able command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It's also recommended to install [`json2hcl`](https://github.com/kvz/json2hcl) a
 
 ## Demo
 
-Let's use the following CloudFormation Stack response as an example:
+Let's use the following CloudFormation Stack response as an example (available as `sample_response.json` in this repository):
 ```
 {
     "Stacks": [
@@ -90,7 +90,7 @@ Let's use the following CloudFormation Stack response as an example:
 }
 ```
 
-Running `cf-to-tf --stack foobarbaz config | json2hcl | cf-to-tf clean-hcl | terraform fmt -` will generate the following config:
+Running `cf-to-tf --stack - config < sample_response.json | json2hcl | cf-to-tf clean-hcl | terraform fmt -` will generate the following config:
 
 ```
 resource "aws_cloudformation_stack" "network" {

--- a/sample_response.json
+++ b/sample_response.json
@@ -1,0 +1,49 @@
+{
+    "Stacks": [
+        {
+            "StackId": "arn:aws:cloudformation:eu-central-1:123456789012:stack/foobarbaz/255491f0-71b8-11e7-a154-500c52a6cefe",
+            "Description": "FooBar Stack",
+            "Parameters": [
+                {
+                    "ParameterValue": "bar",
+                    "ParameterKey": "foo"
+                },
+                {
+                    "ParameterValue": "baz",
+                    "ParameterKey": "bar"
+                },
+                {
+                    "ParameterValue": "qux",
+                    "ParameterKey": "baz"
+
+                }
+            ],
+            "Tags": [
+                {
+                    "Value": "bar",
+                    "Key": "foo"
+                },
+                {
+                    "Value": "qux",
+                    "Key": "baz"
+                }
+            ],
+            "Outputs": [
+                {
+                    "Description": "Foobarbaz",
+                    "OutputKey": "FooBarBaz",
+                    "OutputValue": "output value"
+                }
+            ],
+            "CreationTime": "2017-07-26T04:08:57.266Z",
+            "Capabilities": [
+                "CAPABILITY_IAM"
+            ],
+            "StackName": "foobarbaz",
+            "NotificationARNs": [],
+            "StackStatus": "CREATE_COMPLETE",
+            "DisableRollback": true
+        }
+    ]
+}
+


### PR DESCRIPTION
This may address #8 as it provides a command that can be pasted directly.

Maybe we should add additional wording about the `--stack` parameter? Several reports reflect users passing local paths or URLs vs. names.